### PR TITLE
Apple Sillicon install Guide

### DIFF
--- a/Installation Guide docs/INSTALL-Apple-Silicon.md
+++ b/Installation Guide docs/INSTALL-Apple-Silicon.md
@@ -1,0 +1,291 @@
+# PrismOS Installation on Apple Silicon (M1/M2/M-series)
+
+This guide walks you through installing PrismOS on Apple Silicon Macs (M1, M2, and later). It's written for beginners and focuses on minimizing data loss and enabling an easy rollback.
+
+## What you'll find in this guide
+
+- System requirements
+- Step-by-step installation (preparation, flashing, booting, first-run)
+- Screenshots (placeholders) and how to capture them
+- Troubleshooting
+- FAQ
+- Video tutorial plan and recording script
+
+---
+
+## System requirements
+
+Minimum:
+
+- Mac with Apple Silicon (M1/M2/Pro/Max/Ultra or later). Older Intel Macs are not covered here.
+- macOS 12 Monterey or later (recommended macOS Ventura or newer)
+- 8 GB RAM (4 GB may work for some builds, but 8 GB is recommended)
+- 30 GB free disk space for the installer and temporary files (50 GB recommended if you plan to allocate partitions)
+- USB-C flash drive (16 GB+) for rescue media (optional but recommended)
+- A second working Mac or external storage to keep backup of your data
+
+Software prerequisites:
+
+- Xcode command line tools (for some helper scripts):
+  - Install: `xcode-select --install`
+- Python 3.9+ (system Python may be present). The repository contains Python scripts used by the installer; having a Python 3 interpreter available is helpful.
+- Homebrew is optional but convenient for installing dependencies.
+
+Backups and safety:
+
+- Back up your data (Time Machine or manual copy). Installing OS-level modifications can cause data loss.
+- Have a macOS recovery volume or bootable macOS installer handy to restore the system if needed.
+
+Permissions and security considerations:
+
+- You may need to temporarily reduce security (recovery -> Startup Security Utility) to allow booting from external media. Understand the risks.
+- The guide explains reversible steps where possible.
+
+---
+
+## Step-by-step installation guide
+
+Note: This guide assumes you are comfortable running terminal commands. If not, follow the GUI instructions and ask for help before proceeding.
+
+High-level steps:
+1. Verify hardware & backup
+2. Clone or download PrismOS repository
+3. Prepare the installer and rescue media
+4. Boot into Recovery to adjust security (if required)
+5. Install PrismOS
+6. Post-install verification and cleanup
+
+### 1) Verify hardware & backup
+
+- Check your Mac model and chip:
+  - System Settings > About This Mac (GUI)
+  - or run in Terminal: `sysctl -n machdep.cpu.brand_string || uname -m`
+- Make a full backup. Use Time Machine or copy your home folder to an external drive.
+
+![About This Mac](Installation Guide docs/images/01-about-this-mac.svg)
+Placeholder screenshot: `Installation Guide docs/images/01-about-this-mac.svg`
+
+### 2) Clone or download PrismOS
+
+Open Terminal and run:
+
+```bash
+# clone the repository
+git clone https://github.com/AryanVBW/PrismOS.git
+cd PrismOS
+```
+
+If you already have the repo, `git pull` to update. Verify files like `install.sh`, `osinstall.py`, and `asahi_firmware/` exist.
+
+![Clone Repo](Installation Guide docs/images/02-clone-repo.svg)
+Placeholder screenshot: `Installation Guide docs/images/02-clone-repo.svg`
+
+### 3) Prepare the installer and rescue media
+
+- Install prerequisites (example):
+
+```bash
+# macOS: install Xcode CLT
+xcode-select --install
+
+# Optional: install brew, python, etc.
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+brew install python git
+```
+
+- Create a USB-C rescue stick (optional but recommended):
+
+1. Insert a USB drive (16 GB+). Open Disk Utility and format as "Mac OS Extended (Journaled)" or `exFAT` if you prefer.
+2. Use the included `install.sh` or `osinstall.py` scripts as directed in this repo.
+
+Example (dry-run):
+
+```bash
+# Review the installer script before running
+less install.sh
+
+# Run installer in verbose/dry-run mode if available
+./install.sh --dry-run
+```
+
+![Prepare USB](Installation Guide docs/images/03-prepare-usb.svg)
+Placeholder screenshot: `Installation Guide docs/images/03-prepare-usb.svg`
+
+### 4) Boot into Recovery to adjust security (if required)
+
+Apple Silicon requires shutting down and booting into recovery by holding the power button. Follow Apple's official instructions:
+
+- Shutdown your Mac
+- Press and hold the power button until "Loading startup options" appears
+- Click Options -> Continue -> Utilities -> Startup Security Utility
+- If you need to allow external booting, set "External boot" to "Allow booting from external media" and reduce Secure Boot to "Medium Security" or similar
+
+Important: Re-enable stricter security after installation if you lower it.
+
+![Recovery Options](Installation Guide docs/images/04-recovery-options.svg)
+Placeholder screenshot: `Installation Guide docs/images/04-recovery-options.svg`
+
+### 5) Install PrismOS
+
+This step depends on the installer script. The repo includes `install.sh` and `osinstall.py` which automate many steps. Use these with caution and read the scripts.
+
+Example safe flow:
+
+```bash
+# run in the repo root
+# show what will happen
+./install.sh --check
+
+# when ready, run interactively
+sudo ./install.sh
+```
+
+What the script typically does (read the script to confirm):
+- Verifies firmware blobs and collects asahi_firmware
+- Prepares a new volume/partition or installs to a spare drive
+- Copies files and configures boot entries
+
+If the installer offers a "dry-run" or "--no-write" flag, prefer that first.
+
+![Run Installer](Installation Guide docs/images/05-run-installer.svg)
+Placeholder screenshot: `Installation Guide docs/images/05-run-installer.svg`
+
+### 6) Post-install verification and cleanup
+
+- Reboot the system and choose PrismOS (or the installed volume) from the boot picker (hold power until startup options appear).
+- Verify the kernel and drivers load:
+
+```bash
+# check dmesg for errors
+sudo dmesg | tail -n 200
+
+# check loaded modules or prism-specific logs
+# (replace with actual PrismOS logging commands)
+journalctl -b | head -n 200
+```
+
+- Restore security settings in Recovery -> Startup Security Utility if you changed them.
+
+![First Boot](Installation Guide docs/images/06-first-boot.svg)
+Placeholder screenshot: `Installation Guide docs/images/06-first-boot.svg`
+
+---
+
+## Screenshots and how to contribute them
+
+We included placeholders in `docs/images/`. To add your screenshots:
+Mock screenshots have been added in the respective places
+
+1. Capture a screenshot on macOS with:
+   - Entire screen: Cmd+Shift+3
+   - Selection: Cmd+Shift+4
+2. Rename files using the step prefix and preferred format (SVG or PNG). Example filenames:
+   - `01-about-this-mac.svg` or `01-about-this-mac.png`
+   - `02-clone-repo.svg` or `02-clone-repo.png`
+3. Place files in `docs/images/` and update this markdown only if you change filenames.
+4. Open a PR with the images and the updated markdown. Keep images under 1.5 MB when possible.
+
+Notes:
+- SVGs are preferred for placeholder images (they scale cleanly). For terminal screenshots, PNG is usually better because it preserves pixel-perfect rendering.
+- When capturing terminal output, increase font size and window width so text is readable in thumbnails.
+
+Converting SVG to PNG (optional, local)
+
+If you'd like PNGs for maximum compatibility on all viewers, convert locally using one of these commands on your Mac or Linux machine:
+
+```bash
+# Using rsvg-convert (recommended)
+rsvg-convert -w 1280 -h 720 -o 01-about-this-mac.png 01-about-this-mac.svg
+
+# Using ImageMagick
+magick convert -background none -resize 1280x720 01-about-this-mac.svg 01-about-this-mac.png
+```
+
+Note: This dev environment does not include SVG->PNG conversion tools, so I did not generate PNGs here. If you run the commands above locally and push PNGs to `Installation Guide docs/images/`, I can update the docs in a follow-up PR.
+
+---
+
+## Troubleshooting
+
+Common problems and fixes:
+
+1) Installer aborts with permission errors
+   - Ensure scripts are executable and run with `sudo` if required.
+   - Check file permissions: `ls -l install.sh` and set `chmod +x install.sh`.
+
+2) Mac won't boot external media after installation
+   - Verify Startup Security Utility settings in Recovery.
+   - Recreate rescue USB and try booting from it.
+
+3) Missing drivers or devices (Wi-Fi, Bluetooth, trackpad)
+   - Check `dmesg` or `journalctl` for driver errors
+   - Ensure `asahi_firmware/` has correct blobs. Re-run `./install.sh --fetch-firmware` if present.
+
+4) Kernel panics or hangs on boot
+   - Boot into recovery and restore from backup.
+   - Try safe boot or verbose boot to capture logs: hold power and run options.
+
+Logs to gather when asking for help:
+- `sudo dmesg > /tmp/dmesg.txt`
+- `journalctl -b > /tmp/journal.txt`
+- `system_profiler SPHardwareDataType > /tmp/hardware.txt`
+
+Attach these logs to your issue when filing a bug.
+
+---
+
+## FAQ
+
+Q: Is PrismOS compatible with my Mac?
+A: PrismOS targets Apple Silicon Macs. Compatibility depends on specific hardware revisions and drivers. Check issues and the `asahi_firmware/` directory for supported devices.
+
+Q: Can I dual-boot macOS and PrismOS?
+A: Yes, the installer supports installing to a separate volume or drive. Back up macOS and ensure you choose the correct target during installation.
+
+Q: How do I roll back to macOS only?
+A: Restore from your Time Machine backup or reinstall macOS using a bootable installer.
+
+Q: Where can I get help?
+A: Open an issue in this repository with the logs listed in the Troubleshooting section.
+
+---
+
+## Video tutorial plan (how to create and what to include)
+
+We can't include a video in this repo, but here's a script and checklist for recording a short 5–10 minute tutorial. Contributors can record and upload to YouTube or GitHub Releases.
+
+Suggested structure:
+- Intro (10–20s): What is PrismOS and what the video shows
+- Prereqs & backup (30–45s): Explain requirements and backup step
+- Prepare repo & rescue media (1–2 mins): Show cloning, formatting USB
+- Recovery & security (45–60s): Show entering recovery and security setting
+- Installing (1–2 mins): Run installer with highlights; explain prompts
+- First boot & verification (45–60s): First boot and show logs
+- Troubleshooting tip (30s): Quick fix for a common problem
+- Outro/links (10–20s): Link to repo and docs
+
+Recording checklist:
+- Resolution: 1920x1080
+- Format: MP4 (H.264)
+- Tools: QuickTime Player (macOS), OBS (cross-platform)
+- Microphone: use a clear mic and record short captions
+- Include captions/subtitles for accessibility
+
+Suggested filename: `prismos-install-apple-silicon.mp4`
+
+Upload tips:
+- Host on YouTube (unlisted or public) and link in README
+- Or add a release asset to GitHub Releases
+
+---
+
+## Contributing improvements
+
+- To add real screenshots, create a branch, add images to `docs/images/`, update this markdown to replace placeholders, and open a PR.
+- For video submissions, link the video URL in the README and open a PR to add the link.
+
+---
+
+## Notes and acknowledgements
+
+This guide was prepared for Hacktoberfest 2025 documentation contributions. If you find gaps or have corrections, please open an issue or PR.

--- a/Installation Guide docs/INSTALL-Apple-Silicon.md
+++ b/Installation Guide docs/INSTALL-Apple-Silicon.md
@@ -62,8 +62,8 @@ High-level steps:
   - or run in Terminal: `sysctl -n machdep.cpu.brand_string || uname -m`
 - Make a full backup. Use Time Machine or copy your home folder to an external drive.
 
-![About This Mac](Installation Guide docs/images/01-about-this-mac.svg)
-Placeholder screenshot: `Installation Guide docs/images/01-about-this-mac.svg`
+![About This Mac](images/01-about-this-mac.svg)
+Placeholder screenshot: `images/01-about-this-mac.svg`
 
 ### 2) Clone or download PrismOS
 
@@ -77,8 +77,8 @@ cd PrismOS
 
 If you already have the repo, `git pull` to update. Verify files like `install.sh`, `osinstall.py`, and `asahi_firmware/` exist.
 
-![Clone Repo](Installation Guide docs/images/02-clone-repo.svg)
-Placeholder screenshot: `Installation Guide docs/images/02-clone-repo.svg`
+![Clone Repo](images/02-clone-repo.svg)
+Placeholder screenshot: `images/02-clone-repo.svg`
 
 ### 3) Prepare the installer and rescue media
 
@@ -108,8 +108,8 @@ less install.sh
 ./install.sh --dry-run
 ```
 
-![Prepare USB](Installation Guide docs/images/03-prepare-usb.svg)
-Placeholder screenshot: `Installation Guide docs/images/03-prepare-usb.svg`
+![Prepare USB](images/03-prepare-usb.svg)
+Placeholder screenshot: `images/03-prepare-usb.svg`
 
 ### 4) Boot into Recovery to adjust security (if required)
 
@@ -122,8 +122,8 @@ Apple Silicon requires shutting down and booting into recovery by holding the po
 
 Important: Re-enable stricter security after installation if you lower it.
 
-![Recovery Options](Installation Guide docs/images/04-recovery-options.svg)
-Placeholder screenshot: `Installation Guide docs/images/04-recovery-options.svg`
+![Recovery Options](images/04-recovery-options.svg)
+Placeholder screenshot: `images/04-recovery-options.svg`
 
 ### 5) Install PrismOS
 
@@ -147,8 +147,8 @@ What the script typically does (read the script to confirm):
 
 If the installer offers a "dry-run" or "--no-write" flag, prefer that first.
 
-![Run Installer](Installation Guide docs/images/05-run-installer.svg)
-Placeholder screenshot: `Installation Guide docs/images/05-run-installer.svg`
+![Run Installer](images/05-run-installer.svg)
+Placeholder screenshot: `images/05-run-installer.svg`
 
 ### 6) Post-install verification and cleanup
 
@@ -166,8 +166,8 @@ journalctl -b | head -n 200
 
 - Restore security settings in Recovery -> Startup Security Utility if you changed them.
 
-![First Boot](Installation Guide docs/images/06-first-boot.svg)
-Placeholder screenshot: `Installation Guide docs/images/06-first-boot.svg`
+![First Boot](images/06-first-boot.svg)
+Placeholder screenshot: `images/06-first-boot.svg`
 
 ---
 
@@ -201,7 +201,7 @@ rsvg-convert -w 1280 -h 720 -o 01-about-this-mac.png 01-about-this-mac.svg
 magick convert -background none -resize 1280x720 01-about-this-mac.svg 01-about-this-mac.png
 ```
 
-Note: This dev environment does not include SVG->PNG conversion tools, so I did not generate PNGs here. If you run the commands above locally and push PNGs to `Installation Guide docs/images/`, I can update the docs in a follow-up PR.
+Note: This dev environment does not include SVG->PNG conversion tools, so I did not generate PNGs here. If you run the commands above locally and push PNGs to `images/`, I can update the docs in a follow-up PR.
 
 ---
 

--- a/Installation Guide docs/INSTALL-Apple-Silicon.md
+++ b/Installation Guide docs/INSTALL-Apple-Silicon.md
@@ -118,8 +118,7 @@ Apple Silicon requires shutting down and booting into recovery by holding the po
 - Shutdown your Mac
 - Press and hold the power button until "Loading startup options" appears
 - Click Options -> Continue -> Utilities -> Startup Security Utility
-- If you need to allow external booting, set "External boot" to "Allow booting from external media" and reduce Secure Boot to "Medium Security" or similar
-
+- If you need to allow external booting, set "Allow booting from external or removable media" and set Secure Boot to "Reduced Security"
 Important: Re-enable stricter security after installation if you lower it.
 
 ![Recovery Options](images/04-recovery-options.svg)

--- a/Installation Guide docs/images/01-about-this-mac.svg
+++ b/Installation Guide docs/images/01-about-this-mac.svg
@@ -12,5 +12,5 @@
   <text x="720" y="255" font-family="monospace" font-size="14" fill="#374151">uname -m: x86_64</text>
   <text x="720" y="275" font-family="monospace" font-size="14" fill="#374151">python --version: Python 3.12.1</text>
   <text x="720" y="295" font-family="monospace" font-size="14" fill="#374151">git --version: git version 2.50.1</text>
-  <text x="640" y="640" font-family="monospace" font-size="13" fill="#6b7280" text-anchor="middle">Filename: Installation Guide docs/images/01-about-this-mac.svg — replace with real capture when available</text>
+  <text x="640" y="640" font-family="monospace" font-size="13" fill="#6b7280" text-anchor="middle">Filename: images/01-about-this-mac.svg — replace with real capture when available</text>
 </svg>

--- a/Installation Guide docs/images/01-about-this-mac.svg
+++ b/Installation Guide docs/images/01-about-this-mac.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="720" viewBox="0 0 1280 720">
+  <rect width="100%" height="100%" fill="#f6f8fa"/>
+  <rect x="60" y="60" width="1160" height="600" rx="8" fill="#ffffff" stroke="#d0d7de"/>
+  <text x="640" y="100" font-family="Helvetica, Arial, sans-serif" font-size="26" fill="#0f172a" text-anchor="middle">About This Mac — Mock Capture</text>
+  <rect x="140" y="140" width="1000" height="460" rx="6" fill="#f8fafc" stroke="#e6eef8"/>
+  <text x="220" y="190" font-family="monospace" font-size="16" fill="#0f172a">Model Name: MacBook Pro</text>
+  <text x="220" y="220" font-family="monospace" font-size="16" fill="#0f172a">Chip: Apple M? (replace with your model)</text>
+  <text x="220" y="250" font-family="monospace" font-size="16" fill="#0f172a">Memory: 16 GB</text>
+  <text x="220" y="280" font-family="monospace" font-size="16" fill="#0f172a">macOS Version: macOS 14.x</text>
+  <rect x="720" y="200" width="360" height="220" rx="4" fill="#0f172a" opacity="0.03"/>
+  <text x="720" y="230" font-family="monospace" font-size="14" fill="#374151">Local machine sample outputs (dev container):</text>
+  <text x="720" y="255" font-family="monospace" font-size="14" fill="#374151">uname -m: x86_64</text>
+  <text x="720" y="275" font-family="monospace" font-size="14" fill="#374151">python --version: Python 3.12.1</text>
+  <text x="720" y="295" font-family="monospace" font-size="14" fill="#374151">git --version: git version 2.50.1</text>
+  <text x="640" y="640" font-family="monospace" font-size="13" fill="#6b7280" text-anchor="middle">Filename: Installation Guide docs/images/01-about-this-mac.svg — replace with real capture when available</text>
+</svg>

--- a/Installation Guide docs/images/02-clone-repo.svg
+++ b/Installation Guide docs/images/02-clone-repo.svg
@@ -8,5 +8,5 @@
   <text x="160" y="230" font-family="monospace" font-size="16" fill="#cfe9ff">remote: Enumerating objects: 500, done.</text>
   <text x="160" y="255" font-family="monospace" font-size="16" fill="#cfe9ff">remote: Counting objects: 100% (500/500), done.</text>
   <text x="160" y="280" font-family="monospace" font-size="16" fill="#9fd0ff">Resolving deltas: 100% (300/300), done.</text>
-  <text x="640" y="640" font-family="monospace" font-size="13" fill="#6b7280" text-anchor="middle">Filename: Installation Guide docs/images/02-clone-repo.svg — replace with real capture when available</text>
+  <text x="640" y="640" font-family="monospace" font-size="13" fill="#6b7280" text-anchor="middle">Filename: images/02-clone-repo.svg — replace with real capture when available</text>
 </svg>

--- a/Installation Guide docs/images/02-clone-repo.svg
+++ b/Installation Guide docs/images/02-clone-repo.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="720" viewBox="0 0 1280 720">
+  <rect width="100%" height="100%" fill="#f8fafc"/>
+  <rect x="60" y="60" width="1160" height="600" rx="8" fill="#ffffff" stroke="#e6eef8"/>
+  <text x="640" y="100" font-family="Helvetica, Arial, sans-serif" font-size="26" fill="#0f172a" text-anchor="middle">Clone Repo — Terminal Mock</text>
+  <rect x="120" y="140" width="1040" height="460" rx="6" fill="#0b1220"/>
+  <text x="160" y="180" font-family="monospace" font-size="16" fill="#d1e8ff">$ git clone https://github.com/AryanVBW/PrismOS.git</text>
+  <text x="160" y="205" font-family="monospace" font-size="16" fill="#cfe9ff">Cloning into 'PrismOS'...</text>
+  <text x="160" y="230" font-family="monospace" font-size="16" fill="#cfe9ff">remote: Enumerating objects: 500, done.</text>
+  <text x="160" y="255" font-family="monospace" font-size="16" fill="#cfe9ff">remote: Counting objects: 100% (500/500), done.</text>
+  <text x="160" y="280" font-family="monospace" font-size="16" fill="#9fd0ff">Resolving deltas: 100% (300/300), done.</text>
+  <text x="640" y="640" font-family="monospace" font-size="13" fill="#6b7280" text-anchor="middle">Filename: Installation Guide docs/images/02-clone-repo.svg — replace with real capture when available</text>
+</svg>

--- a/Installation Guide docs/images/03-prepare-usb.svg
+++ b/Installation Guide docs/images/03-prepare-usb.svg
@@ -7,5 +7,5 @@
   <text x="200" y="220" font-family="monospace" font-size="16" fill="#3b2f2f">Name: PRISMOS-RESCUE</text>
   <rect x="200" y="260" width="320" height="120" rx="6" fill="#eef2ff"/>
   <text x="360" y="300" font-family="monospace" font-size="14" fill="#0f172a">Use this USB as rescue media for installing PrismOS</text>
-  <text x="640" y="640" font-family="monospace" font-size="13" fill="#6b7280" text-anchor="middle">Filename: Installation Guide docs/images/03-prepare-usb.svg — replace with real capture when available</text>
+  <text x="640" y="640" font-family="monospace" font-size="13" fill="#6b7280" text-anchor="middle">Filename: images/03-prepare-usb.svg — replace with real capture when available</text>
 </svg>

--- a/Installation Guide docs/images/03-prepare-usb.svg
+++ b/Installation Guide docs/images/03-prepare-usb.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="720" viewBox="0 0 1280 720">
+  <rect width="100%" height="100%" fill="#fffdfa"/>
+  <rect x="60" y="60" width="1160" height="600" rx="8" fill="#ffffff" stroke="#f1e7d6"/>
+  <text x="640" y="100" font-family="Helvetica, Arial, sans-serif" font-size="26" fill="#3b2f2f" text-anchor="middle">Prepare USB — Disk Utility Mock</text>
+  <rect x="140" y="140" width="1000" height="460" rx="6" fill="#ffffff" stroke="#efe6d6"/>
+  <text x="200" y="190" font-family="monospace" font-size="16" fill="#3b2f2f">Select USB Drive → Erase → Format: Mac OS Extended (Journaled)</text>
+  <text x="200" y="220" font-family="monospace" font-size="16" fill="#3b2f2f">Name: PRISMOS-RESCUE</text>
+  <rect x="200" y="260" width="320" height="120" rx="6" fill="#eef2ff"/>
+  <text x="360" y="300" font-family="monospace" font-size="14" fill="#0f172a">Use this USB as rescue media for installing PrismOS</text>
+  <text x="640" y="640" font-family="monospace" font-size="13" fill="#6b7280" text-anchor="middle">Filename: Installation Guide docs/images/03-prepare-usb.svg — replace with real capture when available</text>
+</svg>

--- a/Installation Guide docs/images/04-recovery-options.svg
+++ b/Installation Guide docs/images/04-recovery-options.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="720" viewBox="0 0 1280 720">
+  <rect width="100%" height="100%" fill="#f0f9ff"/>
+  <rect x="60" y="60" width="1160" height="600" rx="8" fill="#ffffff" stroke="#dbeafe"/>
+  <text x="640" y="100" font-family="Helvetica, Arial, sans-serif" font-size="26" fill="#0f172a" text-anchor="middle">Recovery Options — Mock</text>
+  <rect x="140" y="140" width="1000" height="460" rx="6" fill="#eefcff" stroke="#dbeafe"/>
+  <text x="220" y="190" font-family="monospace" font-size="16" fill="#0f172a">Restart and hold the power button until "Loading startup options" appears.</text>
+  <text x="220" y="220" font-family="monospace" font-size="16" fill="#0f172a">Choose: Options → Continue → Utilities → Startup Security Utility</text>
+  <text x="220" y="260" font-family="monospace" font-size="16" fill="#0f172a">Set External Boot: Allow booting from external media (temporary)</text>
+  <text x="640" y="640" font-family="monospace" font-size="13" fill="#6b7280" text-anchor="middle">Filename: Installation Guide docs/images/04-recovery-options.svg — replace with real capture when available</text>
+</svg>

--- a/Installation Guide docs/images/04-recovery-options.svg
+++ b/Installation Guide docs/images/04-recovery-options.svg
@@ -6,5 +6,5 @@
   <text x="220" y="190" font-family="monospace" font-size="16" fill="#0f172a">Restart and hold the power button until "Loading startup options" appears.</text>
   <text x="220" y="220" font-family="monospace" font-size="16" fill="#0f172a">Choose: Options → Continue → Utilities → Startup Security Utility</text>
   <text x="220" y="260" font-family="monospace" font-size="16" fill="#0f172a">Set External Boot: Allow booting from external media (temporary)</text>
-  <text x="640" y="640" font-family="monospace" font-size="13" fill="#6b7280" text-anchor="middle">Filename: Installation Guide docs/images/04-recovery-options.svg — replace with real capture when available</text>
+  <text x="640" y="640" font-family="monospace" font-size="13" fill="#6b7280" text-anchor="middle">Filename: images/04-recovery-options.svg — replace with real capture when available</text>
 </svg>

--- a/Installation Guide docs/images/05-run-installer.svg
+++ b/Installation Guide docs/images/05-run-installer.svg
@@ -7,5 +7,5 @@
   <text x="160" y="205" font-family="monospace" font-size="16" fill="#c7ffd1">[OK] firmware blobs present</text>
   <text x="160" y="230" font-family="monospace" font-size="16" fill="#c7ffd1">[DRYRUN] would create APFS volume: PrismOS-stub</text>
   <text x="160" y="255" font-family="monospace" font-size="16" fill="#a9f7b3">Run without --check to perform the installation</text>
-  <text x="640" y="640" font-family="monospace" font-size="13" fill="#6b7280" text-anchor="middle">Filename: Installation Guide docs/images/05-run-installer.svg — replace with real capture when available</text>
+  <text x="640" y="640" font-family="monospace" font-size="13" fill="#6b7280" text-anchor="middle">Filename: images/05-run-installer.svg — replace with real capture when available</text>
 </svg>

--- a/Installation Guide docs/images/05-run-installer.svg
+++ b/Installation Guide docs/images/05-run-installer.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="720" viewBox="0 0 1280 720">
+  <rect width="100%" height="100%" fill="#f7fff8"/>
+  <rect x="60" y="60" width="1160" height="600" rx="8" fill="#ffffff" stroke="#e6f7ee"/>
+  <text x="640" y="100" font-family="Helvetica, Arial, sans-serif" font-size="26" fill="#0b3d1b" text-anchor="middle">Run Installer — Terminal Mock</text>
+  <rect x="120" y="140" width="1040" height="460" rx="6" fill="#0b1220"/>
+  <text x="160" y="180" font-family="monospace" font-size="16" fill="#d1ffd6">$ sudo ./install.sh --check</text>
+  <text x="160" y="205" font-family="monospace" font-size="16" fill="#c7ffd1">[OK] firmware blobs present</text>
+  <text x="160" y="230" font-family="monospace" font-size="16" fill="#c7ffd1">[DRYRUN] would create APFS volume: PrismOS-stub</text>
+  <text x="160" y="255" font-family="monospace" font-size="16" fill="#a9f7b3">Run without --check to perform the installation</text>
+  <text x="640" y="640" font-family="monospace" font-size="13" fill="#6b7280" text-anchor="middle">Filename: Installation Guide docs/images/05-run-installer.svg — replace with real capture when available</text>
+</svg>

--- a/Installation Guide docs/images/06-first-boot.svg
+++ b/Installation Guide docs/images/06-first-boot.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="720" viewBox="0 0 1280 720">
+  <rect width="100%" height="100%" fill="#fffaf6"/>
+  <rect x="60" y="60" width="1160" height="600" rx="8" fill="#ffffff" stroke="#fff0e0"/>
+  <text x="640" y="100" font-family="Helvetica, Arial, sans-serif" font-size="26" fill="#3a2b1f" text-anchor="middle">First Boot — Logs (mock)</text>
+  <rect x="120" y="140" width="1040" height="460" rx="6" fill="#0b1220"/>
+  <text x="160" y="180" font-family="monospace" font-size="14" fill="#dbe7ff">[    0.000000] Initializing PrismOS kernel</text>
+  <text x="160" y="200" font-family="monospace" font-size="14" fill="#dbe7ff">[    0.123456] asahi_firmware: loaded WiFi firmware</text>
+  <text x="160" y="220" font-family="monospace" font-size="14" fill="#dbe7ff">[    0.456789] network: wlan0: link is up</text>
+  <text x="160" y="240" font-family="monospace" font-size="14" fill="#dbe7ff">[    0.789012] prism-touch: trackpad initialized</text>
+  <text x="640" y="640" font-family="monospace" font-size="13" fill="#6b7280" text-anchor="middle">Filename: Installation Guide docs/images/06-first-boot.svg — replace with real capture when available</text>
+</svg>

--- a/Installation Guide docs/images/06-first-boot.svg
+++ b/Installation Guide docs/images/06-first-boot.svg
@@ -7,5 +7,5 @@
   <text x="160" y="200" font-family="monospace" font-size="14" fill="#dbe7ff">[    0.123456] asahi_firmware: loaded WiFi firmware</text>
   <text x="160" y="220" font-family="monospace" font-size="14" fill="#dbe7ff">[    0.456789] network: wlan0: link is up</text>
   <text x="160" y="240" font-family="monospace" font-size="14" fill="#dbe7ff">[    0.789012] prism-touch: trackpad initialized</text>
-  <text x="640" y="640" font-family="monospace" font-size="13" fill="#6b7280" text-anchor="middle">Filename: Installation Guide docs/images/06-first-boot.svg — replace with real capture when available</text>
+  <text x="640" y="640" font-family="monospace" font-size="13" fill="#6b7280" text-anchor="middle">Filename: images/06-first-boot.svg — replace with real capture when available</text>
 </svg>

--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ The PrismOS Installer is a community-driven project that extends the groundbreak
 -   **Safe & Non-Destructive**: Installs alongside macOS without removing it. The installer safely resizes your existing macOS partition.
 -   **Firmware Extraction**: Automatically extracts the necessary firmware from your macOS installation to make hardware like Wi-Fi and Bluetooth work correctly.
 
+## Installation Documentation
+
+For a detailed, step-by-step installation guide for Apple Silicon Macs (M1/M2/M3/M4), see `docs/INSTALL-Apple-Silicon.md`.
+
 ## ⚙️ How It Works
 
 Installing Linux on Apple Silicon is a complex, two-stage process that the installer automates.


### PR DESCRIPTION
Documentation
Added a dedicated Apple Silicon (M1/M2+) installation guide with step-by-step instructions, system requirements, pre-install prep, recovery/security notes, media creation, installation flow, and post-install checks.
Included troubleshooting, FAQ, screenshot guidance, contribution notes, and a planned video tutorial outline.
Updated main project README to highlight and link the new Apple Silicon installation guide.

# PrismOS Installation on Apple Silicon (M1/M2/M-series)

This guide walks you through installing PrismOS on Apple Silicon Macs (M1, M2, and later). It's written for beginners and focuses on minimizing data loss and enabling an easy rollback.

## What you'll find in this guide

- System requirements
- Step-by-step installation (preparation, flashing, booting, first-run)
- Screenshots (placeholders) and how to capture them
- Troubleshooting
- FAQ
- Video tutorial plan and recording script


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive Apple Silicon installation guide for PrismOS: prerequisites, step‑by‑step install flow, security settings, rescue media creation, post‑install verification, troubleshooting, FAQs, rollback guidance, and contributor notes with placeholder visuals.
  * Updated README to link to the new installation guide (appears in two locations for easier discovery).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->